### PR TITLE
Fix Sturmwind hang (fixes #13)

### DIFF
--- a/core/libretro/libretro.cpp
+++ b/core/libretro/libretro.cpp
@@ -376,7 +376,6 @@ void retro_run (void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
       update_variables();
 
-   poll_cb();
    co_dc_run();
 #if defined(GL) || defined(GLES)
    video_cb(is_dupe ? 0 : RETRO_HW_FRAME_BUFFER_VALID, screen_width, screen_height, 0);
@@ -676,6 +675,7 @@ unsigned retro_api_version(void)
 void os_DoEvents(void)
 {
    is_dupe = false;
+   poll_cb();
 }
 
 void os_CreateWindow()


### PR DESCRIPTION
The problem happened because control flow never returned to retro_run()
so poll_cb() was never called. Moving the call to os_DoEvents() fixes
the issue but requires RetroArch's "Input > Poll Type Behavior" set to
"Normal" so that poll_cb() isn't a no-op.

**(needs review)**